### PR TITLE
Skip generating certain types, inputs and fields

### DIFF
--- a/proto/proto2graphql/option.proto
+++ b/proto/proto2graphql/option.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package proto2graphql;
+
+option java_multiple_files = true;
+option java_outer_classname = "Proto2GraphQLProto";
+option java_package = "proto2graphql";
+
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.FieldOptions {
+  proto2graphql.Option option = 2121;
+}
+
+message Option {
+  bool skip_on_type = 1;
+  bool skip_on_input = 2;
+}

--- a/src/context.ts
+++ b/src/context.ts
@@ -38,7 +38,11 @@ export class Context {
     return this.inputs[name] ?? this.inputs[name + this.inputTypeNameSuffix];
   }
 
-  public getFullTypeName(type: protobuf.ReflectionObject): string {
-    return this.transformTypeName(getFullTypeName(type));
+  public getFullTypeName(type: protobuf.ReflectionObject): { original: string; name: string } {
+    const fullName = getFullTypeName(type);
+    return {
+      name: this.transformTypeName(fullName),
+      original: fullName,
+    };
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,6 +2,8 @@ import { GraphQLOutputType, GraphQLNamedType, GraphQLInputType } from "graphql";
 import { ConvertOptions } from "./options";
 import { getFullTypeName } from "./utils";
 
+const GEN_OPTION_PROTO_PATTERN = /^proto2graphql_/;
+
 export class Context {
   private types: { [name: string]: GraphQLOutputType };
   private inputs: { [name: string]: GraphQLInputType };
@@ -9,15 +11,15 @@ export class Context {
   public readonly generateInputTypes: boolean;
   public readonly inputTypeNameSuffix: string;
   private transformTypeName: (fullName: string) => string;
-  public skipType: (fullName: string) => boolean;
-  public skipInput: (fullName: string) => boolean;
+  private _skipType?: (fullName: string) => boolean;
+  private _skipInput?: (fullName: string) => boolean;
 
   constructor(options?: ConvertOptions) {
     this.generateInputTypes = options?.generateInputTypes ?? false;
     this.inputTypeNameSuffix = options?.inputTypeNameSuffix ?? "Input";
     this.transformTypeName = options?.transformTypeName ?? ((v) => v);
-    this.skipType = options?.skipType ?? (() => false);
-    this.skipInput = options?.skipInput ?? (() => false);
+    this._skipType = options?.skipType;
+    this._skipInput = options?.skipInput;
     this.types = {};
     this.inputs = {};
   }
@@ -44,5 +46,17 @@ export class Context {
       name: this.transformTypeName(fullName),
       original: fullName,
     };
+  }
+
+  public skipType(fullName: string): boolean {
+    if (this._skipType?.(fullName)) return true;
+    if (fullName.match(GEN_OPTION_PROTO_PATTERN)) return true;
+    return false;
+  }
+
+  public skipInput(fullName: string): boolean {
+    if (this._skipInput?.(fullName)) return true;
+    if (fullName.match(GEN_OPTION_PROTO_PATTERN)) return true;
+    return false;
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -9,11 +9,15 @@ export class Context {
   public readonly generateInputTypes: boolean;
   public readonly inputTypeNameSuffix: string;
   private transformTypeName: (fullName: string) => string;
+  public skipType: (fullName: string) => boolean;
+  public skipInput: (fullName: string) => boolean;
 
   constructor(options?: ConvertOptions) {
     this.generateInputTypes = options?.generateInputTypes ?? false;
     this.inputTypeNameSuffix = options?.inputTypeNameSuffix ?? "Input";
     this.transformTypeName = options?.transformTypeName ?? ((v) => v);
+    this.skipType = options?.skipType ?? (() => false);
+    this.skipInput = options?.skipInput ?? (() => false);
     this.types = {};
     this.inputs = {};
   }

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -6,12 +6,12 @@ import { visit } from "./visitor";
 import { Context } from "./context";
 import { ConvertOptions } from "./options";
 
-const PROTO_DIR = path.join(__dirname, "..", "proto");
+const GEN_OPTION_PROTO_DIR = path.join(__dirname, "..", "proto");
 
 export function convert(filename: string, options?: ConvertOptions) {
   const includeDirs: string[] = [];
   if (options?.includeDir) includeDirs.push(options.includeDir);
-  includeDirs.push(PROTO_DIR);
+  includeDirs.push(GEN_OPTION_PROTO_DIR);
 
   const root = new Root();
   root.resolvePath = resolverFactory(root.resolvePath, includeDirs);

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,4 +3,6 @@ export interface ConvertOptions {
   generateInputTypes?: boolean;
   inputTypeNameSuffix?: string;
   transformTypeName?(fullName: string): string;
+  skipType?(fullName: string): boolean;
+  skipInput?(fullName: string): boolean;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,6 +77,17 @@ export function getFieldBehaviors(field: protobuf.Field): FieldBehaviors {
   return fieldBehaviors;
 }
 
+export interface GenerateOption {
+  skipOnType: boolean;
+  skipOnInput: boolean;
+}
+export function getGenerateOption(field: protobuf.Field): GenerateOption {
+  return {
+    skipOnType: !!field.options?.["proto2graphql.option.skipOnType"],
+    skipOnInput: !!field.options?.["proto2graphql.option.skipOnInput"],
+  };
+}
+
 export function wrapType<T extends GraphQLType>(
   type: T,
   repeated: boolean,

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -20,6 +20,7 @@ import {
   FieldBehaviors,
   wrapType,
   sanitizeFieldName,
+  getGenerateOption,
 } from "./utils";
 
 export function visit(objects: protobuf.ReflectionObject[], context: Context) {
@@ -273,6 +274,9 @@ function createOutputFieldType(
     fieldBehaviors.add("OPTIONAL");
   }
 
+  const genOption = getGenerateOption(field);
+  if (genOption.skipOnType) return null;
+
   if (field instanceof protobuf.MapField) {
     return new GraphQLList(context.getType(context.getFullTypeName(field).name));
   }
@@ -293,6 +297,9 @@ function createInputFieldType(
 ): GraphQLInputType | null {
   const fieldBehaviors = getFieldBehaviors(field);
   if (fieldBehaviors.has("OUTPUT_ONLY")) return null;
+
+  const genOption = getGenerateOption(field);
+  if (genOption.skipOnInput) return null;
 
   if (field instanceof protobuf.MapField) {
     return new GraphQLList(context.getType(context.getFullTypeName(field).name));

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -11,7 +11,6 @@ import {
   GraphQLInputFieldConfigMap,
   GraphQLInputType,
   GraphQLEnumValueConfigMap,
-  isObjectType,
 } from "graphql";
 import { Context } from "./context";
 import {
@@ -60,16 +59,20 @@ function visitMessage(
 ): GraphQLNamedType[] {
   const result: GraphQLNamedType[] = [];
 
-  const objectType = new GraphQLObjectType({
-    name: context.getFullTypeName(message),
-    fields: () => createOutputFields(message.fieldsArray, true, context),
-  });
-  context.setType(objectType);
-  result.push(objectType);
+  const fullName = context.getFullTypeName(message);
 
-  if (context.generateInputTypes) {
+  if (!context.skipType(fullName)) {
+    const objectType = new GraphQLObjectType({
+      name: fullName,
+      fields: () => createOutputFields(message.fieldsArray, true, context),
+    });
+    context.setType(objectType);
+    result.push(objectType);
+  }
+
+  if (context.generateInputTypes && !context.skipInput(fullName)) {
     const inputType = new GraphQLInputObjectType({
-      name: context.getFullTypeName(message) + context.inputTypeNameSuffix,
+      name: fullName + context.inputTypeNameSuffix,
       fields: () => createInputFields(message.fieldsArray, true, context),
     });
     context.setInput(inputType);

--- a/test/converter.spec.ts
+++ b/test/converter.spec.ts
@@ -16,7 +16,7 @@ const includeDir = path.join(DIR, "..", "tmp/protos-include");
 describe("converter", () => {
   tests().forEach((test) => {
     it(`handles ${test.replace(/_/g, " ")}`, () => {
-      const generateInputTypes = /field_behavior/.test(test);
+      const generateInputTypes = /field_behavior|skip/.test(test);
 
       const testDir = path.join(DIR, test);
       const actual = convert(path.join(testDir, "input.proto"), {

--- a/test/skip/input.proto
+++ b/test/skip/input.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+import "proto2graphql/option.proto";
+
+message TypeA {
+  string skipOnType = 1 [ proto2graphql.option.skipOnType = true ];
+  string skipOnInput = 2 [ proto2graphql.option.skipOnInput = true ];
+  string skipOnTypeAndInput = 3 [ proto2graphql.option.skipOnType = true, proto2graphql.option.skipOnInput = true ];
+}

--- a/test/skip/output.graphql
+++ b/test/skip/output.graphql
@@ -6,16 +6,6 @@ input TypeAInput {
   skipOnType: String!
 }
 
-type proto2graphql_Option {
-  skipOnType: Boolean!
-  skipOnInput: Boolean!
-}
-
-input proto2graphql_OptionInput {
-  skipOnType: Boolean!
-  skipOnInput: Boolean!
-}
-
 type google_protobuf_FileDescriptorSet {
   file: [google_protobuf_FileDescriptorProto!]
 }
@@ -321,7 +311,6 @@ type google_protobuf_FieldOptions {
   deprecated: Boolean!
   weak: Boolean!
   uninterpretedOption: [google_protobuf_UninterpretedOption!]
-  proto2graphql_option: proto2graphql_Option
 }
 
 input google_protobuf_FieldOptionsInput {
@@ -332,7 +321,6 @@ input google_protobuf_FieldOptionsInput {
   deprecated: Boolean!
   weak: Boolean!
   uninterpretedOption: [google_protobuf_UninterpretedOptionInput!]
-  proto2graphql_option: proto2graphql_OptionInput
 }
 
 enum google_protobuf_FieldOptions_CType {

--- a/test/skip/output.graphql
+++ b/test/skip/output.graphql
@@ -1,13 +1,9 @@
 type TypeA {
-  skipOnType: String!
   skipOnInput: String!
-  skipOnTypeAndInput: String!
 }
 
 input TypeAInput {
   skipOnType: String!
-  skipOnInput: String!
-  skipOnTypeAndInput: String!
 }
 
 type proto2graphql_Option {

--- a/test/skip/output.graphql
+++ b/test/skip/output.graphql
@@ -1,0 +1,486 @@
+type TypeA {
+  skipOnType: String!
+  skipOnInput: String!
+  skipOnTypeAndInput: String!
+}
+
+input TypeAInput {
+  skipOnType: String!
+  skipOnInput: String!
+  skipOnTypeAndInput: String!
+}
+
+type proto2graphql_Option {
+  skipOnType: Boolean!
+  skipOnInput: Boolean!
+}
+
+input proto2graphql_OptionInput {
+  skipOnType: Boolean!
+  skipOnInput: Boolean!
+}
+
+type google_protobuf_FileDescriptorSet {
+  file: [google_protobuf_FileDescriptorProto!]
+}
+
+input google_protobuf_FileDescriptorSetInput {
+  file: [google_protobuf_FileDescriptorProtoInput!]
+}
+
+type google_protobuf_FileDescriptorProto {
+  name: String!
+  package: String!
+  dependency: [String!]
+  publicDependency: [Int!]
+  weakDependency: [Int!]
+  messageType: [google_protobuf_DescriptorProto!]
+  enumType: [google_protobuf_EnumDescriptorProto!]
+  service: [google_protobuf_ServiceDescriptorProto!]
+  extension: [google_protobuf_FieldDescriptorProto!]
+  options: google_protobuf_FileOptions
+  sourceCodeInfo: google_protobuf_SourceCodeInfo
+  syntax: String!
+}
+
+input google_protobuf_FileDescriptorProtoInput {
+  name: String!
+  package: String!
+  dependency: [String!]
+  publicDependency: [Int!]
+  weakDependency: [Int!]
+  messageType: [google_protobuf_DescriptorProtoInput!]
+  enumType: [google_protobuf_EnumDescriptorProtoInput!]
+  service: [google_protobuf_ServiceDescriptorProtoInput!]
+  extension: [google_protobuf_FieldDescriptorProtoInput!]
+  options: google_protobuf_FileOptionsInput
+  sourceCodeInfo: google_protobuf_SourceCodeInfoInput
+  syntax: String!
+}
+
+type google_protobuf_DescriptorProto {
+  name: String!
+  field: [google_protobuf_FieldDescriptorProto!]
+  extension: [google_protobuf_FieldDescriptorProto!]
+  nestedType: [google_protobuf_DescriptorProto!]
+  enumType: [google_protobuf_EnumDescriptorProto!]
+  extensionRange: [google_protobuf_DescriptorProto_ExtensionRange!]
+  oneofDecl: [google_protobuf_OneofDescriptorProto!]
+  options: google_protobuf_MessageOptions
+  reservedRange: [google_protobuf_DescriptorProto_ReservedRange!]
+  reservedName: [String!]
+}
+
+input google_protobuf_DescriptorProtoInput {
+  name: String!
+  field: [google_protobuf_FieldDescriptorProtoInput!]
+  extension: [google_protobuf_FieldDescriptorProtoInput!]
+  nestedType: [google_protobuf_DescriptorProtoInput!]
+  enumType: [google_protobuf_EnumDescriptorProtoInput!]
+  extensionRange: [google_protobuf_DescriptorProto_ExtensionRangeInput!]
+  oneofDecl: [google_protobuf_OneofDescriptorProtoInput!]
+  options: google_protobuf_MessageOptionsInput
+  reservedRange: [google_protobuf_DescriptorProto_ReservedRangeInput!]
+  reservedName: [String!]
+}
+
+type google_protobuf_DescriptorProto_ExtensionRange {
+  start: Int!
+  end: Int!
+  options: google_protobuf_ExtensionRangeOptions
+}
+
+input google_protobuf_DescriptorProto_ExtensionRangeInput {
+  start: Int!
+  end: Int!
+  options: google_protobuf_ExtensionRangeOptionsInput
+}
+
+type google_protobuf_DescriptorProto_ReservedRange {
+  start: Int!
+  end: Int!
+}
+
+input google_protobuf_DescriptorProto_ReservedRangeInput {
+  start: Int!
+  end: Int!
+}
+
+type google_protobuf_ExtensionRangeOptions {
+  uninterpretedOption: [google_protobuf_UninterpretedOption!]
+}
+
+input google_protobuf_ExtensionRangeOptionsInput {
+  uninterpretedOption: [google_protobuf_UninterpretedOptionInput!]
+}
+
+type google_protobuf_FieldDescriptorProto {
+  name: String!
+  number: Int!
+  label: google_protobuf_FieldDescriptorProto_Label!
+  type: google_protobuf_FieldDescriptorProto_Type!
+  typeName: String!
+  extendee: String!
+  defaultValue: String!
+  oneofIndex: Int!
+  jsonName: String!
+  options: google_protobuf_FieldOptions
+  proto3Optional: Boolean!
+}
+
+input google_protobuf_FieldDescriptorProtoInput {
+  name: String!
+  number: Int!
+  label: google_protobuf_FieldDescriptorProto_Label!
+  type: google_protobuf_FieldDescriptorProto_Type!
+  typeName: String!
+  extendee: String!
+  defaultValue: String!
+  oneofIndex: Int!
+  jsonName: String!
+  options: google_protobuf_FieldOptionsInput
+  proto3Optional: Boolean!
+}
+
+enum google_protobuf_FieldDescriptorProto_Type {
+  TYPE_DOUBLE
+  TYPE_FLOAT
+  TYPE_INT64
+  TYPE_UINT64
+  TYPE_INT32
+  TYPE_FIXED64
+  TYPE_FIXED32
+  TYPE_BOOL
+  TYPE_STRING
+  TYPE_GROUP
+  TYPE_MESSAGE
+  TYPE_BYTES
+  TYPE_UINT32
+  TYPE_ENUM
+  TYPE_SFIXED32
+  TYPE_SFIXED64
+  TYPE_SINT32
+  TYPE_SINT64
+}
+
+enum google_protobuf_FieldDescriptorProto_Label {
+  LABEL_OPTIONAL
+  LABEL_REQUIRED
+  LABEL_REPEATED
+}
+
+type google_protobuf_OneofDescriptorProto {
+  name: String!
+  options: google_protobuf_OneofOptions
+}
+
+input google_protobuf_OneofDescriptorProtoInput {
+  name: String!
+  options: google_protobuf_OneofOptionsInput
+}
+
+type google_protobuf_EnumDescriptorProto {
+  name: String!
+  value: [google_protobuf_EnumValueDescriptorProto!]
+  options: google_protobuf_EnumOptions
+  reservedRange: [google_protobuf_EnumDescriptorProto_EnumReservedRange!]
+  reservedName: [String!]
+}
+
+input google_protobuf_EnumDescriptorProtoInput {
+  name: String!
+  value: [google_protobuf_EnumValueDescriptorProtoInput!]
+  options: google_protobuf_EnumOptionsInput
+  reservedRange: [google_protobuf_EnumDescriptorProto_EnumReservedRangeInput!]
+  reservedName: [String!]
+}
+
+type google_protobuf_EnumDescriptorProto_EnumReservedRange {
+  start: Int!
+  end: Int!
+}
+
+input google_protobuf_EnumDescriptorProto_EnumReservedRangeInput {
+  start: Int!
+  end: Int!
+}
+
+type google_protobuf_EnumValueDescriptorProto {
+  name: String!
+  number: Int!
+  options: google_protobuf_EnumValueOptions
+}
+
+input google_protobuf_EnumValueDescriptorProtoInput {
+  name: String!
+  number: Int!
+  options: google_protobuf_EnumValueOptionsInput
+}
+
+type google_protobuf_ServiceDescriptorProto {
+  name: String!
+  method: [google_protobuf_MethodDescriptorProto!]
+  options: google_protobuf_ServiceOptions
+}
+
+input google_protobuf_ServiceDescriptorProtoInput {
+  name: String!
+  method: [google_protobuf_MethodDescriptorProtoInput!]
+  options: google_protobuf_ServiceOptionsInput
+}
+
+type google_protobuf_MethodDescriptorProto {
+  name: String!
+  inputType: String!
+  outputType: String!
+  options: google_protobuf_MethodOptions
+  clientStreaming: Boolean!
+  serverStreaming: Boolean!
+}
+
+input google_protobuf_MethodDescriptorProtoInput {
+  name: String!
+  inputType: String!
+  outputType: String!
+  options: google_protobuf_MethodOptionsInput
+  clientStreaming: Boolean!
+  serverStreaming: Boolean!
+}
+
+type google_protobuf_FileOptions {
+  javaPackage: String!
+  javaOuterClassname: String!
+  javaMultipleFiles: Boolean!
+  javaGenerateEqualsAndHash: Boolean!
+  javaStringCheckUtf8: Boolean!
+  optimizeFor: google_protobuf_FileOptions_OptimizeMode!
+  goPackage: String!
+  ccGenericServices: Boolean!
+  javaGenericServices: Boolean!
+  pyGenericServices: Boolean!
+  phpGenericServices: Boolean!
+  deprecated: Boolean!
+  ccEnableArenas: Boolean!
+  objcClassPrefix: String!
+  csharpNamespace: String!
+  swiftPrefix: String!
+  phpClassPrefix: String!
+  phpNamespace: String!
+  phpMetadataNamespace: String!
+  rubyPackage: String!
+  uninterpretedOption: [google_protobuf_UninterpretedOption!]
+}
+
+input google_protobuf_FileOptionsInput {
+  javaPackage: String!
+  javaOuterClassname: String!
+  javaMultipleFiles: Boolean!
+  javaGenerateEqualsAndHash: Boolean!
+  javaStringCheckUtf8: Boolean!
+  optimizeFor: google_protobuf_FileOptions_OptimizeMode!
+  goPackage: String!
+  ccGenericServices: Boolean!
+  javaGenericServices: Boolean!
+  pyGenericServices: Boolean!
+  phpGenericServices: Boolean!
+  deprecated: Boolean!
+  ccEnableArenas: Boolean!
+  objcClassPrefix: String!
+  csharpNamespace: String!
+  swiftPrefix: String!
+  phpClassPrefix: String!
+  phpNamespace: String!
+  phpMetadataNamespace: String!
+  rubyPackage: String!
+  uninterpretedOption: [google_protobuf_UninterpretedOptionInput!]
+}
+
+enum google_protobuf_FileOptions_OptimizeMode {
+  SPEED
+  CODE_SIZE
+  LITE_RUNTIME
+}
+
+type google_protobuf_MessageOptions {
+  messageSetWireFormat: Boolean!
+  noStandardDescriptorAccessor: Boolean!
+  deprecated: Boolean!
+  mapEntry: Boolean!
+  uninterpretedOption: [google_protobuf_UninterpretedOption!]
+}
+
+input google_protobuf_MessageOptionsInput {
+  messageSetWireFormat: Boolean!
+  noStandardDescriptorAccessor: Boolean!
+  deprecated: Boolean!
+  mapEntry: Boolean!
+  uninterpretedOption: [google_protobuf_UninterpretedOptionInput!]
+}
+
+type google_protobuf_FieldOptions {
+  ctype: google_protobuf_FieldOptions_CType!
+  packed: Boolean!
+  jstype: google_protobuf_FieldOptions_JSType!
+  lazy: Boolean!
+  deprecated: Boolean!
+  weak: Boolean!
+  uninterpretedOption: [google_protobuf_UninterpretedOption!]
+  proto2graphql_option: proto2graphql_Option
+}
+
+input google_protobuf_FieldOptionsInput {
+  ctype: google_protobuf_FieldOptions_CType!
+  packed: Boolean!
+  jstype: google_protobuf_FieldOptions_JSType!
+  lazy: Boolean!
+  deprecated: Boolean!
+  weak: Boolean!
+  uninterpretedOption: [google_protobuf_UninterpretedOptionInput!]
+  proto2graphql_option: proto2graphql_OptionInput
+}
+
+enum google_protobuf_FieldOptions_CType {
+  STRING
+  CORD
+  STRING_PIECE
+}
+
+enum google_protobuf_FieldOptions_JSType {
+  JS_NORMAL
+  JS_STRING
+  JS_NUMBER
+}
+
+type google_protobuf_OneofOptions {
+  uninterpretedOption: [google_protobuf_UninterpretedOption!]
+}
+
+input google_protobuf_OneofOptionsInput {
+  uninterpretedOption: [google_protobuf_UninterpretedOptionInput!]
+}
+
+type google_protobuf_EnumOptions {
+  allowAlias: Boolean!
+  deprecated: Boolean!
+  uninterpretedOption: [google_protobuf_UninterpretedOption!]
+}
+
+input google_protobuf_EnumOptionsInput {
+  allowAlias: Boolean!
+  deprecated: Boolean!
+  uninterpretedOption: [google_protobuf_UninterpretedOptionInput!]
+}
+
+type google_protobuf_EnumValueOptions {
+  deprecated: Boolean!
+  uninterpretedOption: [google_protobuf_UninterpretedOption!]
+}
+
+input google_protobuf_EnumValueOptionsInput {
+  deprecated: Boolean!
+  uninterpretedOption: [google_protobuf_UninterpretedOptionInput!]
+}
+
+type google_protobuf_ServiceOptions {
+  deprecated: Boolean!
+  uninterpretedOption: [google_protobuf_UninterpretedOption!]
+}
+
+input google_protobuf_ServiceOptionsInput {
+  deprecated: Boolean!
+  uninterpretedOption: [google_protobuf_UninterpretedOptionInput!]
+}
+
+type google_protobuf_MethodOptions {
+  deprecated: Boolean!
+  idempotencyLevel: google_protobuf_MethodOptions_IdempotencyLevel!
+  uninterpretedOption: [google_protobuf_UninterpretedOption!]
+}
+
+input google_protobuf_MethodOptionsInput {
+  deprecated: Boolean!
+  idempotencyLevel: google_protobuf_MethodOptions_IdempotencyLevel!
+  uninterpretedOption: [google_protobuf_UninterpretedOptionInput!]
+}
+
+enum google_protobuf_MethodOptions_IdempotencyLevel {
+  IDEMPOTENCY_UNKNOWN
+  NO_SIDE_EFFECTS
+  IDEMPOTENT
+}
+
+type google_protobuf_UninterpretedOption {
+  name: [google_protobuf_UninterpretedOption_NamePart!]
+  identifierValue: String!
+  positiveIntValue: Int!
+  negativeIntValue: Int!
+  doubleValue: Float!
+  stringValue: String!
+  aggregateValue: String!
+}
+
+input google_protobuf_UninterpretedOptionInput {
+  name: [google_protobuf_UninterpretedOption_NamePartInput!]
+  identifierValue: String!
+  positiveIntValue: Int!
+  negativeIntValue: Int!
+  doubleValue: Float!
+  stringValue: String!
+  aggregateValue: String!
+}
+
+type google_protobuf_UninterpretedOption_NamePart {
+  namePart: String!
+  isExtension: Boolean!
+}
+
+input google_protobuf_UninterpretedOption_NamePartInput {
+  namePart: String!
+  isExtension: Boolean!
+}
+
+type google_protobuf_SourceCodeInfo {
+  location: [google_protobuf_SourceCodeInfo_Location!]
+}
+
+input google_protobuf_SourceCodeInfoInput {
+  location: [google_protobuf_SourceCodeInfo_LocationInput!]
+}
+
+type google_protobuf_SourceCodeInfo_Location {
+  path: [Int!]
+  span: [Int!]
+  leadingComments: String!
+  trailingComments: String!
+  leadingDetachedComments: [String!]
+}
+
+input google_protobuf_SourceCodeInfo_LocationInput {
+  path: [Int!]
+  span: [Int!]
+  leadingComments: String!
+  trailingComments: String!
+  leadingDetachedComments: [String!]
+}
+
+type google_protobuf_GeneratedCodeInfo {
+  annotation: [google_protobuf_GeneratedCodeInfo_Annotation!]
+}
+
+input google_protobuf_GeneratedCodeInfoInput {
+  annotation: [google_protobuf_GeneratedCodeInfo_AnnotationInput!]
+}
+
+type google_protobuf_GeneratedCodeInfo_Annotation {
+  path: [Int!]
+  sourceFile: String!
+  begin: Int!
+  end: Int!
+}
+
+input google_protobuf_GeneratedCodeInfo_AnnotationInput {
+  path: [Int!]
+  sourceFile: String!
+  begin: Int!
+  end: Int!
+}


### PR DESCRIPTION
## Why

GraphQL で使わないものを除去する仕組みを作る。

例えば、

- `update_mask` は BFF 上で指定するので web frontend では使わない。
- `message *Request` は input しか必要ない。
- `message *Response` は type しか必要ない。

## What

### message → type + input の制御

Converter を以下のオプションに対応させた。

```ts
skipType?(fullName: string): boolean;
skipInput?(fullName: string): boolean;
```

- `true` を返すと、`fullName` に対応する `type`/`input` が生成されなくなる。
- `transformTypeName` を使用している場合は、変換前の元の名前が `fullName` で渡ってくる。

### field の制御

Field behavior 同様 field options で指定する。

```proto
proto2graphql.option.skipOnType = true;
proto2graphql.option.skipOnInput = true;
```

- `true` を設定したフィールドが `type`/`input` に現れなくなる。
- 同フィールドに両方指定することも可能。
